### PR TITLE
fix(ci): use travis instead of circle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: node_js
+sudo: required
+dist: trusty
+node_js:
+  - '6'
+before_install:
+ - export CHROME_BIN=/usr/bin/google-chrome
+ - export DISPLAY=:99.0
+ - sh -e /etc/init.d/xvfb start
+ - sudo apt-get update
+ - sudo apt-get install -y libappindicator1 fonts-liberation
+ - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+ - sudo dpkg -i google-chrome*.deb
+script:
+  - npm test
+  - npm run enforce
+  - npm run lint

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,0 @@
-machine:
-  node:
-    version: 6
-
-test:
-  post:
-    - npm run enforce
-    - npm run lint


### PR DESCRIPTION
After running through the Angular Bootcamp the first time, I realized that forking a private repo that runs on Circle doesn't mean that those forks can run on Circle. So all in all, I made this repo public and will be building it on Travis now to equate it to BYOAPI and it won't have any issues running it for the forks. I'll also be editing miyagi to mention that the Travis build needs to be turned on.