### PR TITLE
chore(npm): replace nodejitsu references in npm-shrinkwrap.json

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -733,7 +733,7 @@
     "debug": {
       "version": "2.2.0",
       "from": "debug@>=2.1.1 <3.0.0",
-      "resolved": "http://registry.nodejitsu.com/debug/-/debug-2.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
     },
     "decamelize": {
       "version": "1.2.0",
@@ -1040,7 +1040,7 @@
     "esutils": {
       "version": "2.0.2",
       "from": "esutils@>=2.0.2 <3.0.0",
-      "resolved": "http://registry.nodejitsu.com/esutils/-/esutils-2.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
     },
     "event-emitter": {
       "version": "0.3.4",
@@ -4055,7 +4055,7 @@
     "window-size": {
       "version": "0.1.0",
       "from": "window-size@0.1.0",
-      "resolved": "http://registry.nodejitsu.com/window-size/-/window-size-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
     },
     "wordwrap": {
       "version": "0.0.3",


### PR DESCRIPTION
### What & Why

In an attempt to put up a PR on this repo, it looks like [the travis build failed](https://travis-ci.org/lob/postcard-create/builds/152295690) due to nodejitsu issues. So I used @dmlittle's technique and just replaced the URLs with npm's registry.