### PR TITLE
feat(postcard service): Create postcard service and unit test

### DIFF
--- a/app/services/index.js
+++ b/app/services/index.js
@@ -1,16 +1,18 @@
 'use strict';
 
-var Angular = require('angular');
-var Cookies = require('angular-cookies');
+var Angular  = require('angular');
+var Cookies  = require('angular-cookies');
 
-var API     = require('./api');
-var Auth    = require('./auth');
-var Session = require('./session');
+var API      = require('./api');
+var Auth     = require('./auth');
+var Postcard = require('./postcard');
+var Session  = require('./session');
 
 module.exports = Angular.module('postcard-create.services', [
   Cookies
 ])
 .factory('API', API)
 .factory('Auth', Auth)
+.factory('Postcard', Postcard)
 .factory('Session', Session)
 .name;

--- a/app/services/postcard.js
+++ b/app/services/postcard.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var Config = require('../../config');
+
+module.exports = function (API) {
+
+  var Postcard = {};
+
+  Postcard.url = Config.API_HOST + '/postcards';
+
+  Postcard.create = function (payload) {
+    return API.post(this.url, payload);
+  };
+
+  return Postcard;
+
+};

--- a/test/services/postcard.spec.js
+++ b/test/services/postcard.spec.js
@@ -1,0 +1,43 @@
+'use strict';
+
+var expect  = require('chai').expect;
+var Angular = require('angular');
+var Sinon   = require('sinon');
+var Config  = require('../../config');
+
+require('angular-mocks');
+
+describe('postcard service', function () {
+
+  var $q;
+  var $rootScope;
+  var API;
+  var Postcard;
+
+  beforeEach(Angular.mock.inject(function ($injector) {
+    $q         = $injector.get('$q');
+    $rootScope = $injector.get('$rootScope');
+    API        = $injector.get('API');
+    Postcard   = $injector.get('Postcard');
+  }));
+
+  describe('create', function () {
+
+    it('calls the correct endpoint and with correct params', function () {
+      var payload = { id: 'psc_id' };
+
+      Sinon.stub(API, 'post').returns($q.resolve());
+
+      Postcard.create(payload);
+
+      $rootScope.$apply();
+
+      expect(API.post.firstCall.args[0]).to.eql(Config.API_HOST + '/postcards');
+      expect(API.post.firstCall.args[1]).to.eql(payload);
+
+      API.post.restore();
+    });
+
+  });
+
+});


### PR DESCRIPTION
What: Create postcard service and tests.

Why: Want to be able to create new postcards from the dashboard through the API.

Details:

- Added bare bones Postcard service with create method (POST to /postcards).
- Includes unit test.